### PR TITLE
closePanelOnMapLinkOpen

### DIFF
--- a/new-client/src/plugins/DocumentHandler/documentWindow/DocumentWindowBase.js
+++ b/new-client/src/plugins/DocumentHandler/documentWindow/DocumentWindowBase.js
@@ -88,10 +88,10 @@ class DocumentWindowBase extends React.PureComponent {
     const { enqueueSnackbar } = this.props;
     this.snackbarKey = enqueueSnackbar("kartlager laddar...", {
       variant: "information",
-      autoHideDuration: 3000,
+      persist: true,
       preventDuplicate: true,
       transitionDuration: { enter: 0, exit: 0 },
-      anchorOrigin: { vertical: "bottom", horizontal: "left" },
+      anchorOrigin: { vertical: "bottom", horizontal: "center" },
     });
   };
 
@@ -163,11 +163,6 @@ class DocumentWindowBase extends React.PureComponent {
       "core.info-click-documenthandler",
       this.handleInfoClickRequest
     );
-
-    localObserver.subscribe(
-      "map-animation-complete",
-      this.closeMaplinkLoadingBar
-    );
   };
 
   bindSubscriptions = () => {
@@ -175,6 +170,10 @@ class DocumentWindowBase extends React.PureComponent {
     this.bindListenForSearchResultClick();
     localObserver.subscribe("set-active-document", this.showHeaderInDocument);
     localObserver.subscribe("maplink-loading", this.displayMaplinkLoadingBar);
+    localObserver.subscribe(
+      "map-animation-complete",
+      this.closeMaplinkLoadingBar
+    );
   };
 
   setChapterLevels(chapter, level) {

--- a/new-client/src/plugins/DocumentHandler/panelMenu/PanelMenuContainerView.js
+++ b/new-client/src/plugins/DocumentHandler/panelMenu/PanelMenuContainerView.js
@@ -110,6 +110,11 @@ class PanelMenuView extends React.PureComponent {
       window.open(item.link, "_blank");
     });
 
+    localObserver.subscribe("document-maplink-clicked", (maplink) => {
+      localObserver.publish("maplink-loading");
+      this.delayAndFlyToMapLink(maplink);
+    });
+
     localObserver.subscribe("maplink-clicked", (item) => {
       if (!isMobile && this.props.options.closePanelOnMapLinkOpen) {
         localObserver.publish("set-active-document", {
@@ -117,15 +122,21 @@ class PanelMenuView extends React.PureComponent {
           headerIdentifier: null,
         });
         this.props.app.globalObserver.publish("documentviewer.closeWindow");
-        localObserver.publish("maplink-loading");
       }
-      /*otherwise the application freezes when loading slow maplinks
-      before the window closes. 
-      */
-      setTimeout(() => {
-        localObserver.publish("fly-to", item.maplink);
-      }, 100);
+      localObserver.publish("maplink-loading");
+      this.delayAndFlyToMapLink(item.maplink);
     });
+  };
+
+  /*
+  Large maplinks can be slow and cause the application to hang. This delay is a workaround in order
+  allow the other tasks such as closing the document and displaying a snackbar to run before the
+  application hangs.
+  */
+  delayAndFlyToMapLink = (maplink) => {
+    setTimeout(() => {
+      this.props.localObserver.publish("fly-to", maplink);
+    }, 100);
   };
 
   #setInternalId = (menuItem) => {

--- a/new-client/src/plugins/DocumentHandler/utils/ContentComponentFactory.js
+++ b/new-client/src/plugins/DocumentHandler/utils/ContentComponentFactory.js
@@ -524,7 +524,7 @@ export const CustomLink = ({ aTag, localObserver, bottomMargin }) => {
         key="map-link"
         component="button"
         onClick={() => {
-          localObserver.publish("fly-to", mapLink);
+          localObserver.publish("document-maplink-clicked", mapLink);
         }}
       >
         {getFormattedComponentFromTag(aTag)}


### PR DESCRIPTION
Show loading snackbar when maplinks within a document are clicked. 
Minor alterations to existing loading snackbar. 