### PR TITLE
Change to theme based color values as default for document text areas

### DIFF
--- a/backend/mapservice/App_Data/oversiktsplan.json
+++ b/backend/mapservice/App_Data/oversiktsplan.json
@@ -793,8 +793,8 @@
         "drawerTitle": "Översiktsplan",
         "drawerButtonTitle": "Meny",
         "defaultDocumentColorSettings": {
-          "textAreaBackgroundColor": "#ccc",
-          "textAreaDividerColor": "#6A0DAD"
+          "textAreaBackgroundColor": "",
+          "textAreaDividerColor": ""
         },
         "tableOfContents": {
           "expanded": false,

--- a/new-client/src/plugins/DocumentHandler/documentWindow/TableOfContents.js
+++ b/new-client/src/plugins/DocumentHandler/documentWindow/TableOfContents.js
@@ -15,7 +15,7 @@ import {
 const styles = (theme) => {
   return {
     tableOfContents: {
-      backgroundColor: theme.palette.grey[200],
+      backgroundColor: theme.palette.action.selected,
       cursor: "pointer",
       paddingLeft: theme.spacing(2),
       paddingRight: theme.spacing(2),
@@ -23,9 +23,10 @@ const styles = (theme) => {
       paddingBottom: theme.spacing(1),
     },
 
-    test: {
-      backgroundColor: "rgba(0, 0, 0, 0.04)",
+    focusBackground: {
+      backgroundColor: theme.palette.action.selected,
     },
+
     collapseContainer: {
       width: "100%",
     },
@@ -33,7 +34,6 @@ const styles = (theme) => {
     root: {
       width: "100%",
       padding: theme.spacing(0),
-      backgroundColor: theme.palette.grey[200],
     },
   };
 };
@@ -152,7 +152,7 @@ class TableOfContents extends React.PureComponent {
       <Grid className={classes.tableOfContents} container>
         <Button
           disableRipple
-          focusVisibleClassName={classes.test}
+          focusVisibleClassName={classes.focusBackground}
           style={{
             paddingLeft: "0px",
             display: "flex",

--- a/new-client/src/plugins/DocumentHandler/documentWindow/TextArea.js
+++ b/new-client/src/plugins/DocumentHandler/documentWindow/TextArea.js
@@ -9,7 +9,7 @@ const styles = (theme) => {
       overflowWrap: "break-word",
     },
     containerContent: {
-      backgroundColor: "#eeeeee",
+      backgroundColor: theme.palette.action.selected,
     },
     typographyContainer: {
       padding: theme.spacing(1),
@@ -18,7 +18,7 @@ const styles = (theme) => {
       marginBottom: theme.spacing(1),
     },
     divider: {
-      backgroundColor: "#786aaf",
+      backgroundColor: theme.palette.divider,
       height: "2px",
     },
   };


### PR DESCRIPTION
Use Mui theme based values that work with dark mode as a default color value to document text areas. 

This will apply if no document specific color values are set for the document, and values are not set for all documents via defaultDocumentColorSettings in config. 