### PR TITLE
Production URL

### DIFF
--- a/new-client/public/appConfig.json
+++ b/new-client/public/appConfig.json
@@ -2,7 +2,7 @@
   "appName": "Hajk",
   "version": "3.12.0-dev",
   "mapserviceBase": "/api/v1",
-  "proxy": "https://test-webbkarta.nacka.se",
+  "proxy": "https://webbkarta.nacka.se",
   "searchProxy": "",
   "defaultMap": "webbkarta",
   "experimentalNewApi": false,


### PR DESCRIPTION
Works around missing relative URL support for legend graphic. See https://github.com/hajkmap/Hajk/discussions/1396