### PR TITLE
hajkmap/Hajk#1469 Stand-alone GeoWebCache support

### DIFF
--- a/new-admin/public/config.json
+++ b/new-admin/public/config.json
@@ -10,7 +10,8 @@
     "url_wmtslayer_settings": "/api/v1/settings/wmtslayer",
     "url_arcgislayer_settings": "/api/v1/settings/arcgislayer",
     "url_vectorlayer_settings": "/api/v1/settings/vectorlayer",
-    "url_default_server": "https://geoservertest.halmstad.se/geoserver/wms",
+    "default_server_type": "geoserver",
+    "url_default_server": "/geoserver/wms",
     "owner_options": [
       {
         "value": "SBK",
@@ -26,13 +27,13 @@
     "url_proxy": "",
     "url_layers": "/api/v1/config/layers",
     "url_layer_settings": "/api/v1/settings/wfslayer",
-    "url_default_server": "https://giscloud.se/geoserver/wfs"
+    "url_default_server": "/geoserver/wfs"
   },
   "edit": {
     "url_proxy": "",
     "url_layers": "/api/v1/config/layers",
     "url_layer_settings": "/api/v1/settings/wfstlayer",
-    "url_default_server": "https://giscloud.se/geoserver/wfs",
+    "url_default_server": "/geoserver/wfs",
     "projections": [
       "EPSG:3006",
       "EPSG:3007",
@@ -52,7 +53,7 @@
     "url_map_settings": "/api/v1/settings/mapsettings",
     "url_tool_settings": "/api/v1/settings/toolsettings",
     "url_document_list": "/api/v1/informative/list",
-    "url_client_ui": "https://dev-webbkarta-nacka.hajkdemo.sweco.se/",
+    "url_client_ui": "/",
     "authentication_active": false
   },
   "informative": {
@@ -69,7 +70,7 @@
       320564,
       6471766
     ],
-    "wms_url": "http://giscloud.se/mapservice/lmproxy/wms/topowebb",
+    "wms_url": "http://karta.nacka.se/mapservice/lmproxy/wms/topowebb",
     "wms_layers": "topowebbkartan"
   },
   "menueditor": {
@@ -94,7 +95,7 @@
       320564,
       6471766
     ],
-    "wms_url": "http://giscloud.se/mapservice/lmproxy/wms/topowebb",
+    "wms_url": "http://karta.nacka.se/mapservice/lmproxy/wms/topowebb",
     "wms_layers": "topowebbkartan",
     "list_images": "/api/v1/config/listimage",
     "list_videos": "/api/v1/config/listvideo",

--- a/new-admin/public/manifest.json
+++ b/new-admin/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "Hajkmap Administration",
+  "name": "Hajkmap Administrative GUI",
   "icons": [
     {
       "src": "favicon.ico",

--- a/new-admin/src/models/layermanager.js
+++ b/new-admin/src/models/layermanager.js
@@ -5,6 +5,18 @@ import $ from "jquery";
 import { prepareProxyUrl } from "../utils/ProxyHelper";
 import { hfetch } from "utils/FetchWrapper";
 
+const WMS_VERSION_1_3_0 = "1.3.0";
+const WMS_VERSION_1_1_1 = "1.1.1";
+const WMS_VERSION_1_1_0 = "1.1.0";
+const WMS_VERSION_1_0_0 = "1.0.0";
+
+const defaultVersions = [
+  WMS_VERSION_1_3_0,
+  WMS_VERSION_1_1_1,
+  WMS_VERSION_1_1_0,
+  WMS_VERSION_1_0_0
+];
+
 var manager = Model.extend({
   defaults: {
     layers: [],
@@ -380,7 +392,7 @@ var manager = Model.extend({
     });
   },
 
-  getAllWMSCapabilities: function (url) {
+  getAllWMSCapabilities: function (url, versions = defaultVersions) {
     var promises = [];
 
     var xmlParser = new X2JS({
@@ -392,8 +404,6 @@ var manager = Model.extend({
         "WMT_MS_Capabilities.Capability.Layer.Layer.Style",
       ],
     });
-
-    var versions = ["1.3.0", "1.1.1", "1.1.0", "1.0.0"];
 
     versions.forEach((version) => {
       promises.push(
@@ -458,4 +468,4 @@ var manager = Model.extend({
   },
 });
 
-export default manager;
+export { manager as default, WMS_VERSION_1_0_0, WMS_VERSION_1_1_0, WMS_VERSION_1_1_1, WMS_VERSION_1_3_0 };

--- a/new-admin/src/views/layermanager.jsx
+++ b/new-admin/src/views/layermanager.jsx
@@ -666,6 +666,7 @@ class Manager extends Component {
             layer={this.state.layer}
             parent={this}
             url={this.props.config.url_default_server}
+            serverType={this.props.config.default_server_type}
           />
         );
       case "WMTS":
@@ -676,6 +677,7 @@ class Manager extends Component {
             layer={this.state.layer}
             parent={this}
             url={this.props.config.url_default_server}
+            serverType={this.props.config.default_server_type}
           />
         );
       case "ArcGIS":
@@ -686,6 +688,7 @@ class Manager extends Component {
             layer={this.state.layer}
             parent={this}
             url={this.props.config.url_default_server}
+            serverType={this.props.config.default_server_type}
           />
         );
       case "Vector":
@@ -696,6 +699,7 @@ class Manager extends Component {
             layer={this.state.layer}
             parent={this}
             url={this.props.config.url_default_server}
+            serverType={this.props.config.default_server_type}
           />
         );
       default:

--- a/new-client/public/appConfig.json
+++ b/new-client/public/appConfig.json
@@ -1,6 +1,6 @@
 {
   "appName": "Hajk",
-  "version": "3.12.0-dev+1399",
+  "version": "3.12.0-dev+1399+1469",
   "mapserviceBase": "/api/v1",
   "experimentalNewApi": false,
   "proxy": "",

--- a/new-client/src/utils/ConfigMapper.js
+++ b/new-client/src/utils/ConfigMapper.js
@@ -74,6 +74,27 @@ export default class ConfigMapper {
       });
     }
 
+    /**
+     * Returns OpenLayers server type string, given Hajk server type as input.
+     * Certain Hajk server types are used only for admin interface and configuration switching,
+     * but being treated as a common OL server-type in the client.
+     * @param hajkServerType Hajk server type from config
+     * @returns OpenLayers server type as string
+     */
+    function getOpenLayersServerType(hajkServerType) {
+      if (!hajkServerType) {
+        return null;
+      }
+      switch (hajkServerType) {
+        case "geowebcache-standalone":
+          return "geoserver";
+        case "arcgis":
+          return "mapserver";
+        default:
+          return hajkServerType;
+      }
+    }
+
     function mapLayersInfo(layersInfo, infobox) {
       if (Array.isArray(layersInfo)) {
         return layersInfo.reduce((layersInfoObject, layerInfo) => {
@@ -150,10 +171,7 @@ export default class ConfigMapper {
         customDpiList: args.customDpiList,
         customRatio: args.customRatio,
         imageFormat: args.imageFormat || "image/png",
-        serverType:
-          args.serverType === "arcgis"
-            ? "mapserver"
-            : args.serverType || "geoserver",
+        serverType: getOpenLayersServerType(args.serverType),
         crossOrigin: properties.mapConfig.map.crossOrigin || "anonymous",
         attribution: args.attribution,
         showAttributeTableButton: args.showAttributeTableButton,


### PR DESCRIPTION
* Add support for new WMS server type "geowebcache-standalone"
* Use constants for WMS versions and server types
* Add optional support for configuring default server type as well as the existing default URL (fall back to "geoserver" if not present/backwards compatible)